### PR TITLE
fix: move popup POST params from URL query string to request body

### DIFF
--- a/Api/Module/PopupInterface.php
+++ b/Api/Module/PopupInterface.php
@@ -22,18 +22,38 @@ interface PopupInterface
     public function getPopupPreview($popupType);
 
     /**
-     * Register a customer subscription to the popup
+     * Register a customer subscription to the popup.
+     * All sensitive fields are read from the POST body, never from URL parameters.
      * @param string $popupType Popup type (e.g., "promoCodeFirstPurchase")
+     * @param string|null $email Customer email address
+     * @param bool $subscribe Whether the customer subscribed to the newsletter
+     * @param string|null $phone Customer phone number
+     * @param string|null $birthday Customer birthday (YYYY-MM-DD, DD/MM/YYYY or MM/DD/YYYY)
+     * @param bool $optin_sms Whether the customer opted in to SMS
+     * @param string|null $captcha reCAPTCHA token
+     * @param string|null $campaignId Campaign ID
+     * @param string|null $quizAnswers JSON-encoded array of quiz answers
      * @return bool
      */
-    public function registerSubscription($popupType);
+    public function registerSubscription(
+        $popupType,
+        $email = null,
+        $subscribe = false,
+        $phone = null,
+        $birthday = null,
+        $optin_sms = false,
+        $captcha = null,
+        $campaignId = null,
+        $quizAnswers = null
+    );
 
     /**
      * Forward a popup display hit to Kiliba without local persistence.
      * @param string $popupType Popup type (e.g., "promoCodeFirstPurchase")
+     * @param string|null $displayData JSON-encoded display data
      * @return bool
      */
-    public function registerDisplay($popupType);
+    public function registerDisplay($popupType, $displayData = null);
 
     /**
      * Update popup configuration (via private API)

--- a/Model/Api/Popup.php
+++ b/Model/Api/Popup.php
@@ -299,11 +299,18 @@ class Popup extends AbstractApiAction implements PopupInterface
     /**
      * {@inheritdoc}
      */
-    public function registerSubscription($popupType)
-    {
+    public function registerSubscription(
+        $popupType,
+        $email = null,
+        $subscribe = false,
+        $phone = null,
+        $birthday = null,
+        $optin_sms = false,
+        $captcha = null,
+        $campaignId = null,
+        $quizAnswers = null
+    ) {
         try {
-            // Get email from request
-            $email = $this->_request->getParam('email');
             if (!$email) {
                 $this->logRegistrationFailure($email, "Missing email");
                 sleep(2);
@@ -346,10 +353,10 @@ class Popup extends AbstractApiAction implements PopupInterface
             }
 
             // Get subscription status
-            $hasSubscribed = $this->_request->getParam('subscribe') === 'true';
-            $phone = trim((string)$this->_request->getParam('phone'));
-            $rawBirthday = trim((string)$this->_request->getParam('birthday'));
-            $optinSms = $this->_request->getParam('optin_sms') === 'true';
+            $hasSubscribed = $subscribe === true || $subscribe === 'true';
+            $phone = trim((string)$phone);
+            $rawBirthday = trim((string)$birthday);
+            $optinSms = $optin_sms === true || $optin_sms === 'true';
 
             // Check lang (store locale)
             $idLang = $this->_configHelper->getStoreLocale($storeId);
@@ -365,7 +372,7 @@ class Popup extends AbstractApiAction implements PopupInterface
                 $websiteId
             );
             $popupConfiguration = json_decode($popupConfigJson, true);
-            $campaignId = (string)($this->_request->getParam('campaignId') ?: '');
+            $campaignId = (string)($campaignId ?: '');
             $popupEffectiveConfiguration = $this->getCampaignSubmissionConfiguration($popupConfiguration, $campaignId);
             if (!$popupEffectiveConfiguration) {
                 $this->logRegistrationFailure($email, "Popup campaign unavailable");
@@ -466,8 +473,7 @@ class Popup extends AbstractApiAction implements PopupInterface
                     sleep(2);
                     return $this->jsonResponse(400, "INVALID_CAPTCHA_SETUP");
                 }
-                $token = $this->_request->getParam('captcha');
-                $captchaVerification = $this->verifyCaptcha($popupEffectiveConfiguration['captcha']['secretkey'], $token);
+                $captchaVerification = $this->verifyCaptcha($popupEffectiveConfiguration['captcha']['secretkey'], $captcha);
                 if (!$captchaVerification || !$captchaVerification->success) {
                     $this->logRegistrationFailure($email, "Invalid captcha token");
                     sleep(2);
@@ -520,7 +526,7 @@ class Popup extends AbstractApiAction implements PopupInterface
             $popupCustomer->setEmail($email);
             $popupCustomer->setData('phone', $phone);
             $popupCustomer->setData('birthday', $birthday);
-            $quizAnswers = json_decode((string)$this->_request->getParam('quizAnswers'), true);
+            $quizAnswers = json_decode((string)$quizAnswers, true);
             $popupCustomer->setData('quiz_answers', is_array($quizAnswers) && count($quizAnswers) > 0 ? json_encode($quizAnswers) : null);
             $quizAttributes = $this->buildPopupQuizAttributes($campaignId, is_array($quizAnswers) ? $quizAnswers : [], $popupEffectiveConfiguration);
             $popupCustomer->setData('quiz_attributes', is_array($quizAttributes) && count($quizAttributes) > 0 ? json_encode($quizAttributes) : null);
@@ -563,7 +569,7 @@ class Popup extends AbstractApiAction implements PopupInterface
     /**
      * {@inheritdoc}
      */
-    public function registerDisplay($popupType)
+    public function registerDisplay($popupType, $displayData = null)
     {
         try {
             if ($popupType === "promoCodeFirstPurchase") {
@@ -576,7 +582,6 @@ class Popup extends AbstractApiAction implements PopupInterface
             $storeId = $store->getId();
             $websiteId = $store->getWebsiteId();
 
-            $displayData = $this->_request->getParam('displayData');
             if (is_string($displayData)) {
                 $displayData = json_decode($displayData, true);
             }


### PR DESCRIPTION
Privacy fix - GDPR Article 25 (privacy by design) - personal data must not be transmitted unencrypted in URLs.

Now : email, subscribe, phone, optin_sms, captcha, campaignId, quizAnswers and displayData were all read via getParam() which resolves URL query parameters — exposing PII (email, phone) in server logs, browser history and referrer headers.

By declaring these values as explicit method parameters on PopupInterface::registerSubscription() and ::registerDisplay(), Magento's REST framework maps them from the JSON request body instead, so nothing sensitive ever appears in the URL.